### PR TITLE
Fix check mk xinetd rhel

### DIFF
--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -43,7 +43,12 @@ class check_mk::agent::config (
     $only_from = undef
   }
 
-  file { '/etc/xinetd.d/check_mk':
+  $xinetd_file = $::osfamily ? {
+    'RedHat' => '/etc/xinetd.d/check-mk-agent',
+    default  => '/etc/xinetd.d/check_mk',
+  }
+
+  file { $xinetd_file:
     ensure  => present,
     owner   => 'root',
     group   => 'root',

--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -49,13 +49,20 @@ class check_mk::agent::config (
   }
 
   file { $xinetd_file:
-    ensure  => present,
+    ensure  => 'file',
     owner   => 'root',
     group   => 'root',
     mode    => '0444',
     content => template('check_mk/agent/check_mk.erb'),
     require => Package['check_mk-agent'],
     notify  => Class['check_mk::agent::service'],
+  }
+
+  # Delete file from older check_mk package version
+  if $::osfamily == 'RedHat' {
+    file { '/etc/xinetd.d/check_mk':
+      ensure => 'absent',
+    }
   }
 }
 


### PR DESCRIPTION
On RHEL latest check-mk-agent package from EPEL did change the location of the xinet conf file.
