### PR TITLE
 Set optional parameters to be undefined and include agent classes instead of instantiating them

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -10,21 +10,11 @@ class check_mk::agent (
   $workspace    = '/root/check_mk',
   $package      = undef,
 ) {
-  class { 'check_mk::agent::install':
-    version   => $version,
-    filestore => $filestore,
-    workspace => $workspace,
-    package   => $package,
-  }
-  class { 'check_mk::agent::config':
-    ip_whitelist => $ip_whitelist,
-    port         => $port,
-    server_dir   => $server_dir,
-    use_cache    => $use_cache,
-    user         => $user,
-    require      => Class['check_mk::agent::install'],
-  }
+  include check_mk::agent::install
+  include check_mk::agent::config
   include check_mk::agent::service
+  Class['check_mk::agent::install'] ->
+  Class['check_mk::agent::config']
   @@check_mk::host { $::fqdn:
     host_tags => $host_tags,
   }

--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -25,12 +25,12 @@
 #   Default: undef
 #
 class check_mk::agent::config (
-  $ip_whitelist = undef,
-  $port         = undef,
-  $server_dir   = undef,
-  $use_cache    = undef,
-  $user         = undef,
-) {
+  $ip_whitelist = $check_mk::agent::ip_whitelist,
+  $port         = $check_mk::agent::port,
+  $server_dir   = $check_mk::agent::server_dir,
+  $use_cache    = $check_mk::agent::use_cache,
+  $user         = $check_mk::agent::user,
+) inherits check_mk::agent {
   if $use_cache {
     $server = "${server_dir}/check_mk_caching_agent"
   } else {

--- a/manifests/agent/config.pp
+++ b/manifests/agent/config.pp
@@ -26,10 +26,10 @@
 #
 class check_mk::agent::config (
   $ip_whitelist = undef,
-  $port = undef,
-  $server_dir = undef,
-  $use_cache = undef,
-  $user = undef,
+  $port         = undef,
+  $server_dir   = undef,
+  $use_cache    = undef,
+  $user         = undef,
 ) {
   if $use_cache {
     $server = "${server_dir}/check_mk_caching_agent"

--- a/manifests/agent/install.pp
+++ b/manifests/agent/install.pp
@@ -1,9 +1,9 @@
 class check_mk::agent::install (
-  $version   = undef,
+  $version   = $check_mk::agent::version,
   $filestore = undef,
-  $workspace = undef,
+  $workspace = $check_mk::agent::workspace,
   $package   = undef,
-) {
+) inherits check_mk::agent {
   if ! defined(Package['xinetd']) {
     package { 'xinetd':
       ensure => present,

--- a/manifests/agent/install.pp
+++ b/manifests/agent/install.pp
@@ -10,6 +10,10 @@ class check_mk::agent::install (
     }
   }
   if $filestore {
+    if ! $version {
+      fail('version must be specified.')
+    }
+
     if ! defined(File[$workspace]) {
       file { $workspace:
         ensure => directory,

--- a/manifests/agent/install.pp
+++ b/manifests/agent/install.pp
@@ -1,8 +1,8 @@
 class check_mk::agent::install (
-  $version,
-  $filestore,
-  $workspace,
-  $package,
+  $version   = undef,
+  $filestore = undef,
+  $workspace = undef,
+  $package   = undef,
 ) {
   if ! defined(Package['xinetd']) {
     package { 'xinetd':

--- a/spec/classes/check_mk_agent_config_spec.rb
+++ b/spec/classes/check_mk_agent_config_spec.rb
@@ -4,7 +4,6 @@ describe 'check_mk::agent::config', :type => :class do
   context 'Redhat Linux' do
     let :facts do
       {
-          :kernel   => 'Linux',
           :osfamily => 'RedHat',
       }
     end
@@ -14,9 +13,23 @@ describe 'check_mk::agent::config', :type => :class do
                       with_content(/^\tport\s+ = $/).
                       with_content(/^\tuser\s+ = $/).
                       with_content(/^\tserver\s+ = \/check_mk_agent$/).
-                      without_content(/only_from/)
+                      without_content(/only_from/).
+                      with_notify('Class[Check_mk::Agent::Service]')
       }
       it { should contain_file('/etc/xinetd.d/check_mk').with_ensure('absent') }
+    end
+  end
+
+  context 'Other OS' do
+    context 'with defaults for all parameters' do
+      it { should contain_file('/etc/xinetd.d/check_mk').
+                      with_content(/^\tport\s+ = $/).
+                      with_content(/^\tuser\s+ = $/).
+                      with_content(/^\tserver\s+ = \/check_mk_agent$/).
+                      without_content(/only_from/).
+                      with_notify('Class[Check_mk::Agent::Service]')
+      }
+      it { should_not contain_file('/etc/xinetd.d/check_mk').with_ensure('absent') }
     end
   end
 end

--- a/spec/classes/check_mk_agent_config_spec.rb
+++ b/spec/classes/check_mk_agent_config_spec.rb
@@ -10,24 +10,57 @@ describe 'check_mk::agent::config', :type => :class do
     context 'with defaults for all parameters' do
       it { should contain_class('check_mk::agent::config') }
       it { should contain_file('/etc/xinetd.d/check-mk-agent').
-                      with_content(/^\tport\s+ = $/).
-                      with_content(/^\tuser\s+ = $/).
-                      with_content(/^\tserver\s+ = \/check_mk_agent$/).
-                      without_content(/only_from/).
-                      with_notify('Class[Check_mk::Agent::Service]')
+          with_content(/^\tport\s+ = 6556$/).
+          with_content(/^\tuser\s+ = root$/).
+          with_content(/^\tserver\s+ = \/usr\/bin\/check_mk_agent$/).
+          without_content(/only_from/).
+          with_notify('Class[Check_mk::Agent::Service]')
       }
       it { should contain_file('/etc/xinetd.d/check_mk').with_ensure('absent') }
+    end
+    context 'with use_cache' do
+      let :params do
+        {
+            :use_cache => true,
+        }
+      end
+      it { should contain_file('/etc/xinetd.d/check-mk-agent').
+          with_content(/^\tserver\s+ = \/usr\/bin\/check_mk_caching_agent$/)
+      }
+    end
+    context 'with ip_whitelist' do
+      let :params do
+        {
+            :ip_whitelist => [
+                '1.2.3.4',
+                '5.6.7.8',
+            ],
+        }
+      end
+      it { should contain_file('/etc/xinetd.d/check-mk-agent').
+          with_content(/^\tonly_from\s+= 127.0.0.1 1.2.3.4 5.6.7.8$/)
+      }
+    end
+    context 'with custom user' do
+      let :params do
+        {
+            :user => 'custom',
+        }
+      end
+      it { should contain_file('/etc/xinetd.d/check-mk-agent').
+          with_content(/^\tuser\s+ = custom$/)
+      }
     end
   end
 
   context 'Other OS' do
     context 'with defaults for all parameters' do
       it { should contain_file('/etc/xinetd.d/check_mk').
-                      with_content(/^\tport\s+ = $/).
-                      with_content(/^\tuser\s+ = $/).
-                      with_content(/^\tserver\s+ = \/check_mk_agent$/).
-                      without_content(/only_from/).
-                      with_notify('Class[Check_mk::Agent::Service]')
+          with_content(/^\tport\s+ = 6556$/).
+          with_content(/^\tuser\s+ = root$/).
+          with_content(/^\tserver\s+ = \/usr\/bin\/check_mk_agent$/).
+          without_content(/only_from/).
+          with_notify('Class[Check_mk::Agent::Service]')
       }
       it { should_not contain_file('/etc/xinetd.d/check_mk').with_ensure('absent') }
     end

--- a/spec/classes/check_mk_agent_install_spec.rb
+++ b/spec/classes/check_mk_agent_install_spec.rb
@@ -34,28 +34,43 @@ describe 'check_mk::agent::install', :type => :class do
     end
 
     context 'with filestore' do
-      let :params do
-        {
-            :version   => '1.2.3',
-            :filestore => '/filestore',
-            :workspace => '/workspace',
-            :package   => 'custom-package',
+      context 'without version' do
+        let :params do
+          {
+              :filestore => '/filestore',
+          }
+        end
+        it 'should fail' do
+          expect { catalogue }.to raise_error(Puppet::Error, /version must be specified/)
+        end
+      end
+      context 'with custom parameters' do
+        let :params do
+          {
+              :version   => '1.2.3',
+              :filestore => '/filestore',
+              :workspace => '/workspace',
+          }
+        end
+        it { should contain_class('check_mk::agent::install') }
+        it { should contain_package('xinetd') }
+        it { should contain_file('/workspace').with_ensure('directory') }
+        it { should contain_File('/workspace/check_mk-agent-1.2.3.noarch.rpm').with(
+            {
+                :ensure  => 'present',
+                :source  => '/filestore/check_mk-agent-1.2.3.noarch.rpm',
+                :require => 'Package[xinetd]',
+            }
+          ).that_comes_before('Package[check_mk-agent]')
+        }
+        it { should contain_package('check_mk-agent').with(
+            {
+                :provider => 'rpm',
+                :source   => '/workspace/check_mk-agent-1.2.3.noarch.rpm',
+            }
+        )
         }
       end
-      it { should contain_class('check_mk::agent::install') }
-      it { should contain_package('xinetd') }
-      it { should contain_file('/workspace').with_ensure('directory') }
-      it { should contain_File('/workspace/check_mk-agent-1.2.3.noarch.rpm').with({
-            :ensure  => 'present',
-            :source  => '/filestore/check_mk-agent-1.2.3.noarch.rpm',
-            :require => 'Package[xinetd]',
-        }).that_comes_before('Package[check_mk-agent]')
-      }
-      it { should contain_package('check_mk-agent').with({
-            :provider => 'rpm',
-            :source   => '/workspace/check_mk-agent-1.2.3.noarch.rpm',
-        })
-      }
     end
   end
 

--- a/spec/classes/check_mk_agent_install_spec.rb
+++ b/spec/classes/check_mk_agent_install_spec.rb
@@ -9,7 +9,15 @@ describe 'check_mk::agent::install', :type => :class do
     end
 
     context 'with default parameters' do
-      it { should contain_class('check_mk::agent::install') }
+      it { should contain_class('check_mk::agent::install').with(
+          {
+              :version   => nil,
+              :filestore => nil,
+              :workspace => '/root/check_mk',
+              :package   => nil,
+          }
+        )
+      }
       it { should contain_package('xinetd') }
       it { should contain_package('check_mk-agent').with_name('check-mk-agent') }
     end

--- a/spec/classes/check_mk_agent_install_spec.rb
+++ b/spec/classes/check_mk_agent_install_spec.rb
@@ -4,17 +4,19 @@ describe 'check_mk::agent::install', :type => :class do
   context 'RedHat Linux' do
     let :facts do
       {
-          :kernel => 'Linux',
-          :operatingsystem => 'Redhat',
           :osfamily => 'Redhat',
       }
     end
-    context 'with necessary parameters set' do
+
+    context 'with default parameters' do
+      it { should contain_class('check_mk::agent::install') }
+      it { should contain_package('xinetd') }
+      it { should contain_package('check_mk-agent').with_name('check-mk-agent') }
+    end
+
+    context 'with custom package' do
       let :params do
         {
-            :version => '1.2.3',
-            :filestore => false,
-            :workspace => '/workspace',
             :package => 'custom-package',
         }
       end
@@ -49,4 +51,46 @@ describe 'check_mk::agent::install', :type => :class do
     end
   end
 
+  context 'Debian Linux' do
+    let :facts do
+      {
+          :osfamily => 'Debian',
+      }
+    end
+
+    context 'with default parameters' do
+      it { should contain_class('check_mk::agent::install') }
+      it { should contain_package('xinetd') }
+      it { should contain_package('check_mk-agent').with_name('check-mk-agent') }
+    end
+
+    context 'with custom package' do
+      let :params do
+        {
+            :package => 'custom-package',
+        }
+      end
+      it { should contain_class('check_mk::agent::install') }
+      it { should contain_package('xinetd') }
+      it { should contain_package('check_mk-agent').with_name('custom-package') }
+    end
+  end
+
+  context 'Unknown OS' do
+    context 'with default parameters' do
+      it { should contain_class('check_mk::agent::install') }
+      it { should contain_package('xinetd') }
+      it { should contain_package('check_mk-agent').with_name('check_mk-agent') }
+    end
+    context 'with custom package' do
+      let :params do
+        {
+            :package => 'custom-package',
+        }
+      end
+      it { should contain_class('check_mk::agent::install') }
+      it { should contain_package('xinetd') }
+      it { should contain_package('check_mk-agent').with_name('custom-package') }
+    end
+  end
 end


### PR DESCRIPTION
The parameters in the class check_mk::agent::install should be optional. In the default case it should be possible to only include the class and let the osfamily-specific package be installed by it.

Now it is possible to include the agent classes instead of instantiating them.
