### PR TITLE
Adding check_mk::agent::mrpe to configure mrpe lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,6 @@ script:
   - puppet --version
   - bundle exec rake validate lint spec
 matrix:
-  include:
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 3.7.0" RSPEC_GEM_VERSION="< 3.2.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 3.8.0" RSPEC_GEM_VERSION="< 3.2.0"
   exclude:
     - rvm: 2.2
       env: PUPPET_GEM_VERSION="~> 3.7.0"

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Only required if a filestore is used.
 *workspace*: The directory to use to store files used during installation.
 Default: '/root/check_mk'
 
+*mrpe_checks*: Specifies a hash of check_mk::agent::mrpe resources to create. Default: {}
+
 ## Host groups and tags
 
 By default check_mk puts all hosts into a group called 'check_mk' but where you

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -9,7 +9,9 @@ class check_mk::agent (
   $version      = undef,
   $workspace    = '/root/check_mk',
   $package      = undef,
+  $mrpe_checks  = {},
 ) {
+  validate_hash($mrpe_checks)
   include check_mk::agent::install
   include check_mk::agent::config
   include check_mk::agent::service
@@ -18,4 +20,5 @@ class check_mk::agent (
   @@check_mk::host { $::fqdn:
     host_tags => $host_tags,
   }
+  create_resources('check_mk::agent::mrpe', $mrpe_checks)
 }

--- a/manifests/agent/mrpe.pp
+++ b/manifests/agent/mrpe.pp
@@ -20,7 +20,7 @@
 # * Bas Grolleman <bgrolleman@emendo-it.nl>
 #
 define check_mk::agent::mrpe (
-  $command
+  $command,
 ) {
   $mrpe_config_file = $::operatingsystem ? {
     centos  => '/etc/check-mk-agent/mrpe.cfg',

--- a/manifests/agent/mrpe.pp
+++ b/manifests/agent/mrpe.pp
@@ -1,0 +1,44 @@
+#
+# Add entry to the mrpe.cfg file
+#
+### Parameters
+#
+### command
+#
+# The command to run
+#
+### Example
+#
+# ```
+# check_mk::agent::mrpe { 'Test':
+#   command => '/bin/true'
+# }
+# ```
+#
+## Authors
+#
+# * Bas Grolleman <bgrolleman@emendo-it.nl>
+#
+define check_mk::agent::mrpe (
+  $command
+) {
+  $mrpe_config_file = $::operatingsystem ? {
+    centos  => '/etc/check-mk-agent/mrpe.cfg',
+    redhat  => '/etc/check-mk-agent/mrpe.cfg',
+    default => undef
+  }
+
+  if ( $mrpe_config_file ) {
+    if ! defined(Concat[$mrpe_config_file]) {
+      concat { $mrpe_config_file:
+        ensure => 'present';
+      }
+    }
+    concat::fragment { $name:
+      target  => $mrpe_config_file,
+      content => "${name} ${command}\n"
+    }
+  } else {
+    fail("Creating mrpe.cfg is unsupported for operatingsystem ${::operatingsystem}")
+  }
+}

--- a/manifests/agent/mrpe.pp
+++ b/manifests/agent/mrpe.pp
@@ -31,10 +31,10 @@ define check_mk::agent::mrpe (
   if ( $mrpe_config_file ) {
     if ! defined(Concat[$mrpe_config_file]) {
       concat { $mrpe_config_file:
-        ensure => 'present';
+        ensure => 'present'
       }
     }
-    concat::fragment { $name:
+    concat::fragment { "${name}-mrpe-check":
       target  => $mrpe_config_file,
       content => "${name} ${command}\n"
     }

--- a/spec/classes/check_mk_agent_spec.rb
+++ b/spec/classes/check_mk_agent_spec.rb
@@ -3,9 +3,9 @@ describe 'check_mk::agent', :type => :class do
   context 'Redhat Linux' do
     let :facts do
       {
-          :kernel => 'Linux',
+          :kernel          => 'Linux',
           :operatingsystem => 'Redhat',
-          :osfamily => 'Redhat',
+          :osfamily        => 'Redhat',
       }
     end
     context 'with defaults for all parameters' do
@@ -13,6 +13,31 @@ describe 'check_mk::agent', :type => :class do
       it { should contain_class('check_mk::agent::install').that_comes_before('Class[check_mk::agent::config]') }
       it { should contain_class('check_mk::agent::config') }
       it { should contain_class('check_mk::agent::service') }
+    end
+    context 'with mrpe_checks' do
+      context 'not a hash' do
+        let :params do
+          {
+              :mrpe_checks => 'not_a_hash',
+          }
+        end
+        it 'should fail' do
+          expect { catalogue }.to raise_error(Puppet::Error, /\"not_a_hash\" is not a Hash./)
+        end
+      end
+      context 'defined correctly' do
+        let :params do
+          {
+              :mrpe_checks => {
+                  'check1' => {'command' => 'command1'},
+                  'check2' => {'command' => 'command2'},
+              }
+          }
+        end
+        it { should contain_class('check_mk::agent') }
+        it { should contain_check_mk__agent__mrpe('check1').with_command('command1') }
+        it { should contain_check_mk__agent__mrpe('check2').with_command('command2') }
+      end
     end
   end
 end

--- a/spec/defines/check_mk_agent_mrpe_spec.rb
+++ b/spec/defines/check_mk_agent_mrpe_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+describe 'check_mk::agent::mrpe', :type => :define do
+  let :title do
+    'mrpe'
+  end
+  context 'Unsupported OS' do
+    context 'with mandatory command' do
+      let :params do
+        {:command => 'command'}
+      end
+      it 'should fail' do
+        expect { catalogue }.to raise_error(Puppet::Error, /Creating mrpe.cfg is unsupported for operatingsystem/)
+      end
+    end
+  end
+  context 'RedHat Linux' do
+    let :facts do
+      {
+          :operatingsystem => 'redhat',
+      }
+    end
+    context 'with mandatory command' do
+      let :params do
+        {:command => 'command'}
+      end
+      it { should contain_check_mk__agent__mrpe('mrpe') }
+      it { should contain_concat('/etc/check-mk-agent/mrpe.cfg').with_ensure('present') }
+      it { should contain_concat__fragment('mrpe').with({
+            :target  => '/etc/check-mk-agent/mrpe.cfg',
+            :content => /^mrpe command\n$/,
+        })
+      }
+    end
+  end
+end

--- a/spec/defines/check_mk_agent_mrpe_spec.rb
+++ b/spec/defines/check_mk_agent_mrpe_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 describe 'check_mk::agent::mrpe', :type => :define do
   let :title do
-    'mrpe'
+    'checkname'
   end
   context 'Unsupported OS' do
     context 'with mandatory command' do
@@ -23,11 +23,11 @@ describe 'check_mk::agent::mrpe', :type => :define do
       let :params do
         {:command => 'command'}
       end
-      it { should contain_check_mk__agent__mrpe('mrpe') }
+      it { should contain_check_mk__agent__mrpe('checkname') }
       it { should contain_concat('/etc/check-mk-agent/mrpe.cfg').with_ensure('present') }
-      it { should contain_concat__fragment('mrpe').with({
+      it { should contain_concat__fragment('checkname-mrpe-check').with({
             :target  => '/etc/check-mk-agent/mrpe.cfg',
-            :content => /^mrpe command\n$/,
+            :content => /^checkname command\n$/,
         })
       }
     end


### PR DESCRIPTION
Merge commit https://github.com/sanoma-technology/puppet-check_mk/commit/c1e94657f8a864c594fb5a177a76bb558cbe8f14 from @bgrolleman and extend functionality of class check_mk::agent to create check_mk::agent::mrpe resources.
