### PR TITLE
Allow more overrides when configuring a check_mk server

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,9 +1,11 @@
 class check_mk (
-  $filestore   = undef,
-  $host_groups = undef,
-  $package     = 'omd-0.56',
-  $site        = 'monitoring',
-  $workspace   = '/root/check_mk',
+  $checkmk_service  = $checkmk::params::checkmk_service,
+  $filestore        = $checkmk::params::filestore
+  $host_groups      = $checkmk::params::host_groups,
+  $httpd_service    = $checkmk::params::httpd_service,
+  $package          = $checkmk::params::package,
+  $site             = $checkmk::params::site,
+  $workspace        = $checkmk::params::workspace,
 ) {
   class { 'check_mk::install':
     filestore => $filestore,
@@ -17,6 +19,8 @@ class check_mk (
     require     => Class['check_mk::install'],
   }
   class { 'check_mk::service':
-    require   => Class['check_mk::config'],
+    checmk_service => $checkmk_service,
+    httpd_service  => $httpd_service,
+    require        => Class['check_mk::config'],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,7 @@
 class check_mk (
   $checkmk_service  = $check_mk::params::checkmk_service,
-  $filestore        = undef,
-  $host_groups      = undef,
+  $filestore        = $check_mk::params::filestore,
+  $host_groups      = $check_mk::params::host_groups,
   $httpd_service    = $check_mk::params::httpd_service,
   $package          = $check_mk::params::package,
   $site             = $check_mk::params::site,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,12 +1,13 @@
 class check_mk (
-  $checkmk_service  = $checkmk::params::checkmk_service,
-  $filestore        = $checkmk::params::filestore
-  $host_groups      = $checkmk::params::host_groups,
-  $httpd_service    = $checkmk::params::httpd_service,
-  $package          = $checkmk::params::package,
-  $site             = $checkmk::params::site,
-  $workspace        = $checkmk::params::workspace,
-) {
+  $checkmk_service  = $check_mk::params::checkmk_service,
+  $filestore        = undef,
+  $host_groups      = undef,
+  $httpd_service    = $check_mk::params::httpd_service,
+  $package          = $check_mk::params::package,
+  $site             = $check_mk::params::site,
+  $workspace        = $check_mk::params::workspace,
+) inherits check_mk::params {
+
   class { 'check_mk::install':
     filestore => $filestore,
     package   => $package,
@@ -19,7 +20,7 @@ class check_mk (
     require     => Class['check_mk::install'],
   }
   class { 'check_mk::service':
-    checmk_service => $checkmk_service,
+    checkmk_service => $checkmk_service,
     httpd_service  => $httpd_service,
     require        => Class['check_mk::config'],
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,6 +1,6 @@
 class check_mk::install (
-  $filestore,
-  $package,
+  $filestore = undef,
+  $package = undef,
   $site,
   $workspace,
 ) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,8 +1,14 @@
 class check_mk::params {
-  # general settings
-  $checkmk_service = 'omd'
 
-  # OS specific
+  # common variables
+  $checkmk_service = 'omd'
+  $package = 'omd-0.56'
+  $filestore = undef
+  $host_groups= undef
+  $site = 'monitoring'
+  $workspace = '/root/check_mk'
+
+  # OS specific variables
   case $::osfamily {
     'RedHat': {
       $httpd_service = 'httpd'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,14 @@
+class check_mk::params {
+  # general settings
+  $checkmk_service = 'omd'
+
+  # OS specific
+  case $::osfamily {
+    'RedHat': {
+      $httpd_service = 'httpd'
+    }
+    'Debian': {
+      $httpd_service = 'apache2'
+    }
+  }
+}

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,6 +1,9 @@
-class check_mk::service {
-  if ! defined(Service[httpd]) {
-    service { 'httpd':
+class check_mk::service (
+  $checkmk_service,
+  $httpd_service, 
+) {
+  if ! defined(Service[$httpd_service]) {
+    service { "$httpd_service":
       ensure => 'running',
       enable => true,
     }
@@ -11,7 +14,7 @@ class check_mk::service {
       enable => true,
     }
   }
-  service { 'omd':
+  service { $service:
     ensure => 'running',
     enable => true,
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -14,7 +14,7 @@ class check_mk::service (
       enable => true,
     }
   }
-  service { $service:
+  service { $checkmk_service:
     ensure => 'running',
     enable => true,
   }


### PR DESCRIPTION
I moved the params in init.pp to a params.pp file, and made check_mk service and httpd_service a configurable param. 

In the params.pp there's now a default for Debian like systems that use apache2 as httpd_service.
